### PR TITLE
Loads translations from the EN language if it does not find a transla…

### DIFF
--- a/src/NovaMediaFieldServiceProvider.php
+++ b/src/NovaMediaFieldServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Ferdiunal\NovaMediaField;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nova\Events\ServingNova;
@@ -21,10 +22,20 @@ class NovaMediaFieldServiceProvider extends ServiceProvider
         });
 
         Nova::serving(function (ServingNova $event) {
-            Nova::script('nova-media', realpath(__DIR__.'/../dist/js/field.js'));
-            Nova::style('nova-media', realpath(__DIR__.'/../dist/css/field.css'));
-            Nova::translations(realpath(__DIR__.sprintf('/../lang/%s/nova-media.json', $this->app->getLocale())));
+            Nova::script('nova-media', realpath(__DIR__ . '/../dist/js/field.js'));
+            Nova::style('nova-media', realpath(__DIR__ . '/../dist/css/field.css'));
+            $this->translations();
         });
+    }
+
+    private function translations()
+    {
+        $translate = realpath(__DIR__ . sprintf('/../lang/%s/nova-media.json', $this->app->getLocale()));
+        if (File::exists($translate)) {
+            Nova::translations($translate);
+        } else {
+            Nova::translations(realpath(__DIR__ . '/../lang/en/nova-media.json'));
+        }
     }
 
     protected function routes()
@@ -35,7 +46,7 @@ class NovaMediaFieldServiceProvider extends ServiceProvider
 
         Route::middleware(['nova'])
             ->prefix('nova-vendor/ferdiunal/laravel-nova-media-field')
-            ->group(__DIR__.'/../routes/api.php');
+            ->group(__DIR__ . '/../routes/api.php');
     }
 
     /**


### PR DESCRIPTION
When I set a language other than EN in `./config/app.php`, the plugin returned an error

```
array_merge(): Argument #2 must be of type array, false given
```

The modification will check whether such a file exists, if not, it will fallback to EN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced localization support for media selection with a new Slovak translation file.
  
- **Enhancements**
  - Improved the loading mechanism for translation files, providing a fallback to English if the specified locale is not found.
  - Adjusted path concatenation for script and style loading for better readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->